### PR TITLE
Add test for aliased types and fix map aliases

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -111,16 +111,12 @@ func (w *walker) Map(m reflect.Value) error {
 		return nil
 	}
 
-	// Get the type for the map
-	t := m.Type()
-	mapType := reflect.MapOf(t.Key(), t.Elem())
-
 	// Create the map. If the map itself is nil, then just make a nil map
 	var newMap reflect.Value
 	if m.IsNil() {
-		newMap = reflect.Indirect(reflect.New(mapType))
+		newMap = reflect.Indirect(reflect.New(m.Type()))
 	} else {
-		newMap = reflect.MakeMap(reflect.MapOf(t.Key(), t.Elem()))
+		newMap = reflect.MakeMap(m.Type())
 	}
 
 	w.cs = append(w.cs, newMap)

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -192,3 +192,27 @@ func TestCopy_time(t *testing.T) {
 		t.Fatalf("bad: %#v", result)
 	}
 }
+
+func TestCopy_aliased(t *testing.T) {
+	type (
+		Int   int
+		Str   string
+		Map   map[Int]interface{}
+		Slice []Str
+	)
+
+	v := Map{
+		1: Map{10: 20},
+		2: Map(nil),
+		3: Slice{"a", "b"},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}


### PR DESCRIPTION
Hi.

This PR fixes a bug when `copystructure` drops type aliases for maps.