### PR TITLE
Don't panic trying to set an unexprted field

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -95,7 +95,9 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 		if v.IsValid() {
 			s := w.cs[len(w.cs)-1]
 			sf := reflect.Indirect(s).FieldByName(f.Name)
-			sf.Set(v)
+			if sf.CanSet() {
+				sf.Set(v)
+			}
 		}
 	case reflectwalk.WalkLoc:
 		// Clear out the slices for GC

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -176,6 +176,28 @@ func TestCopy_structUnexported(t *testing.T) {
 	}
 }
 
+func TestCopy_nestedStructUnexported(t *testing.T) {
+	type subTest struct {
+		mine string
+	}
+
+	type test struct {
+		Value   string
+		private subTest
+	}
+
+	v := test{Value: "foo"}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestCopy_time(t *testing.T) {
 	type test struct {
 		Value time.Time


### PR DESCRIPTION
Nested structs with unexported fields would panic while copying.
Test that a field can be set before attempting to set it.