### PR TITLE
Modify Copy to automatically lock sync.Lockers

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -12,11 +12,6 @@ func Copy(v interface{}) (interface{}, error) {
 	return Config{}.Copy(v)
 }
 
-// LockedCopy returns a deep copy of v, taking locks as needed during the walk.
-func LockedCopy(v interface{}) (interface{}, error) {
-	return Config{Lock: true}.Copy(v)
-}
-
 // CopierFunc is a function that knows how to deep copy a specific type.
 // Register these globally with the Copiers variable.
 type CopierFunc func(interface{}) (interface{}, error)

--- a/copystructure.go
+++ b/copystructure.go
@@ -9,12 +9,12 @@ import (
 
 // Copy returns a deep copy of v.
 func Copy(v interface{}) (interface{}, error) {
-	return Opts{}.Copy(v)
+	return Config{}.Copy(v)
 }
 
 // LockedCopy returns a deep copy of v, taking locks as needed during the walk.
 func LockedCopy(v interface{}) (interface{}, error) {
-	return Opts{Lock: true}.Copy(v)
+	return Config{Lock: true}.Copy(v)
 }
 
 // CopierFunc is a function that knows how to deep copy a specific type.
@@ -32,7 +32,7 @@ type CopierFunc func(interface{}) (interface{}, error)
 // this map as well as to Copy in a mutex.
 var Copiers map[reflect.Type]CopierFunc = make(map[reflect.Type]CopierFunc)
 
-type Opts struct {
+type Config struct {
 	// Lock any types that are a sync.Locker and are not a mutex while copying.
 	// If there is an RLocker method, use that to get the sync.Locker.
 	Lock bool
@@ -42,14 +42,14 @@ type Opts struct {
 	Copiers map[reflect.Type]CopierFunc
 }
 
-func (o Opts) Copy(v interface{}) (interface{}, error) {
+func (c Config) Copy(v interface{}) (interface{}, error) {
 	w := new(walker)
-	if o.Lock {
+	if c.Lock {
 		w.useLocks = true
 	}
 
-	if o.Copiers == nil {
-		o.Copiers = Copiers
+	if c.Copiers == nil {
+		c.Copiers = Copiers
 	}
 
 	err := reflectwalk.Walk(v, w)

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -258,7 +258,7 @@ func TestCopy_embeddedLocker(t *testing.T) {
 	copied := make(chan bool)
 
 	go func() {
-		result, err = LockedCopy(v)
+		result, err = Config{Lock: true}.Copy(v)
 		close(copied)
 	}()
 
@@ -306,12 +306,12 @@ func TestCopy_lockRace(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			LockedCopy(v)
+			Config{Lock: true}.Copy(v)
 		}()
 	}
 
 	wg.Wait()
-	result, err := LockedCopy(v)
+	result, err := Config{Lock: true}.Copy(v)
 
 	// test that the mutex is in the correct state
 	result.(*EmbeddedLocker).Lock()
@@ -352,7 +352,7 @@ func TestCopy_lockedField(t *testing.T) {
 	copied := make(chan bool)
 
 	go func() {
-		result, err = LockedCopy(v)
+		result, err = Config{Lock: true}.Copy(v)
 		close(copied)
 	}()
 
@@ -402,7 +402,7 @@ func TestCopy_lockedMap(t *testing.T) {
 	copied := make(chan bool)
 
 	go func() {
-		result, err = LockedCopy(v)
+		result, err = Config{Lock: true}.Copy(v)
 		close(copied)
 	}()
 
@@ -447,7 +447,7 @@ func TestCopy_rLocker(t *testing.T) {
 	copied := make(chan bool)
 
 	go func() {
-		result, err = LockedCopy(v)
+		result, err = Config{Lock: true}.Copy(v)
 		close(copied)
 	}()
 
@@ -470,7 +470,7 @@ func TestCopy_rLocker(t *testing.T) {
 
 	// now make sure we can copy during an RLock
 	v.RLock()
-	result, err = LockedCopy(v)
+	result, err = Config{Lock: true}.Copy(v)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,7 +493,7 @@ func TestCopy_missingLockedField(t *testing.T) {
 		String: "orig",
 	}
 
-	result, err := LockedCopy(v)
+	result, err := Config{Lock: true}.Copy(v)
 
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -2,6 +2,7 @@ package copystructure
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -230,6 +231,194 @@ func TestCopy_aliased(t *testing.T) {
 	}
 
 	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+type EmbeddedLocker struct {
+	sync.Mutex
+	Map map[int]int
+}
+
+func TestCopy_EmbeddedLocker(t *testing.T) {
+	v := &EmbeddedLocker{
+		Map: map[int]int{42: 111},
+	}
+	// start locked to prevent copying
+	v.Lock()
+
+	var result interface{}
+	var err error
+
+	copied := make(chan bool)
+
+	go func() {
+		result, err = Copy(v)
+		close(copied)
+	}()
+
+	// pause slightly to make sure copying is blocked
+	select {
+	case <-copied:
+		t.Fatal("copy completed while locked!")
+	case <-time.After(100 * time.Millisecond):
+		v.Unlock()
+	}
+
+	<-copied
+
+	// test that the mutex is in the correct state
+	result.(*EmbeddedLocker).Lock()
+	result.(*EmbeddedLocker).Unlock()
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+// this will trigger the race detector, and usually panic if the original
+// struct isn't properly locked during Copy
+func TestCopy_lockRace(t *testing.T) {
+	v := &EmbeddedLocker{
+		Map: map[int]int{},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				v.Lock()
+				v.Map[i] = i
+				v.Unlock()
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Copy(v)
+		}()
+	}
+
+	wg.Wait()
+	result, err := Copy(v)
+
+	// test that the mutex is in the correct state
+	result.(*EmbeddedLocker).Lock()
+	result.(*EmbeddedLocker).Unlock()
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+type LockedField struct {
+	String string
+	Locker *EmbeddedLocker
+	// this should not get locked or have its state copied
+	Mutex sync.Mutex
+}
+
+func TestCopy_LockedField(t *testing.T) {
+	v := &LockedField{
+		String: "orig",
+		Locker: &EmbeddedLocker{
+			Map: map[int]int{42: 111},
+		},
+	}
+
+	// start locked to prevent copying
+	v.Locker.Lock()
+	v.Mutex.Lock()
+
+	var result interface{}
+	var err error
+
+	copied := make(chan bool)
+
+	go func() {
+		result, err = Copy(v)
+		close(copied)
+	}()
+
+	// pause slightly to make sure copying is blocked
+	select {
+	case <-copied:
+		t.Fatal("copy completed while locked!")
+	case <-time.After(100 * time.Millisecond):
+		v.Locker.Unlock()
+	}
+
+	<-copied
+
+	// test that the mutexes are in the correct state
+	result.(*LockedField).Locker.Lock()
+	result.(*LockedField).Locker.Unlock()
+	result.(*LockedField).Mutex.Lock()
+	result.(*LockedField).Mutex.Unlock()
+
+	// this wasn't  blocking, but should be unlocked for DeepEqual
+	v.Mutex.Unlock()
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("expected:\n%#v\nbad:\n%#v\n", v, result)
+	}
+}
+
+// test something that doesn't contain a lock internally
+type lockedMap map[int]int
+
+var mapLock sync.Mutex
+
+func (m lockedMap) Lock()   { mapLock.Lock() }
+func (m lockedMap) Unlock() { mapLock.Unlock() }
+
+func TestCopy_LockedMap(t *testing.T) {
+	v := lockedMap{1: 2}
+	v.Lock()
+
+	var result interface{}
+	var err error
+
+	copied := make(chan bool)
+
+	go func() {
+		result, err = Copy(v)
+		close(copied)
+	}()
+
+	// pause slightly to make sure copying is blocked
+	select {
+	case <-copied:
+		t.Fatal("copy completed while locked!")
+	case <-time.After(100 * time.Millisecond):
+		v.Unlock()
+	}
+
+	<-copied
+
+	// test that the mutex is in the correct state
+	result.(lockedMap).Lock()
+	result.(lockedMap).Unlock()
+
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
Whenever a value which is also a sync.Locker is encountered during Copy,
and it isn't specifically a sync.Mutex or sync.RWMutex, we lock it while
copying any part of that value.