### PR TITLE
Don't call Interface() on a non-pointer values

### DIFF
--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -529,3 +529,21 @@ func TestCopy_mapWithNil(t *testing.T) {
 		t.Fatalf("expected:\n%#v\ngot:\n%#v", v, result)
 	}
 }
+
+// While this is safe to lock and copy directly, copystructure requires a
+// pointer to reflect the value safely.
+func TestCopy_valueWithLockPointer(t *testing.T) {
+	v := struct {
+		*sync.Mutex
+		X int
+	}{
+		Mutex: &sync.Mutex{},
+		X:     3,
+	}
+
+	_, err := Config{Lock: true}.Copy(v)
+
+	if err != errPointerRequired {
+		t.Fatalf("expected errPointerRequired, got: %v", err)
+	}
+}

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -402,7 +402,7 @@ func TestCopy_lockedMap(t *testing.T) {
 	copied := make(chan bool)
 
 	go func() {
-		result, err = Config{Lock: true}.Copy(v)
+		result, err = Config{Lock: true}.Copy(&v)
 		close(copied)
 	}()
 


### PR DESCRIPTION
Calling Interface() on a relect.Value requires a copy, so it's not safe
to call on a non-pointer value to check for the lock methods. This is OK
since a pointer to a sync.Locker still satisfies the interface. It will
however require that cal call to Copy with Lock set to true can only
accept a pointer argument, even if the value is safe to Lock/Unlock.