### PR TITLE
Copy should not copy unexported fields

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -295,10 +295,22 @@ func (w *walker) StructField(f reflect.StructField, v reflect.Value) error {
 		return nil
 	}
 
+	// If PkgPath is non-empty, this is a private (unexported) field.
+	// We do not set this unexported since the Go runtime doesn't allow us.
+	if f.PkgPath != "" {
+		w.ignore()
+		return nil
+	}
+
 	// Push the field onto the stack, we'll handle it when we exit
 	// the struct field in Exit...
 	w.valPush(reflect.ValueOf(f))
 	return nil
+}
+
+// ignore causes the walker to ignore any more values until we exit this on
+func (w *walker) ignore() {
+	w.ignoreDepth = w.depth
 }
 
 func (w *walker) ignoring() bool {

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -177,6 +177,38 @@ func TestCopy_structUnexported(t *testing.T) {
 	}
 }
 
+func TestCopy_structUnexportedMap(t *testing.T) {
+	type Sub struct {
+		Foo map[string]interface{}
+	}
+
+	type test struct {
+		Value string
+
+		private Sub
+	}
+
+	v := test{
+		Value: "foo",
+		private: Sub{
+			Foo: map[string]interface{}{
+				"yo": 42,
+			},
+		},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// private should not be copied
+	v.private = Sub{}
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad:\n\n%#v\n\n%#v", result, v)
+	}
+}
+
 func TestCopy_nestedStructUnexported(t *testing.T) {
 	type subTest struct {
 		mine string


### PR DESCRIPTION
Fairly straightforward, I guess we just never tried to copy anything with an unexported field before!

The behavior before would never _set_ an unexported field (we did have tests for that) but it would actually recurse into it, read its contents, and initialize a copy of it all to zero values. This surprisingly works for primitives but doesn't work for things like maps (which this PR tests). 

The new behavior changes it so when it sees an unexported field it just ignores the rest of that field. This should actually result in better performance (CPU and memory) while also being more robust.