### PR TITLE
Fix primitive pointer test

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -77,7 +77,7 @@ type walker struct {
 	ignoreDepth int
 	vals        []reflect.Value
 	cs          []reflect.Value
-	ps          []bool
+	ps          []int
 
 	// any locks we've taken, indexed by depth
 	locks []sync.Locker
@@ -93,6 +93,10 @@ func (w *walker) Enter(l reflectwalk.Location) error {
 		w.locks = append(w.locks, nil)
 	}
 
+	for len(w.ps) < w.depth+1 {
+		w.ps = append(w.ps, 0)
+	}
+
 	return nil
 }
 
@@ -103,6 +107,7 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 		defer locker.Unlock()
 	}
 
+	w.ps[w.depth] = 0
 	w.depth--
 	if w.ignoreDepth > w.depth {
 		w.ignoreDepth = 0
@@ -154,6 +159,7 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 		if v.IsValid() {
 			s := w.cs[len(w.cs)-1]
 			sf := reflect.Indirect(s).FieldByName(f.Name)
+
 			if sf.CanSet() {
 				sf.Set(v)
 			}
@@ -191,20 +197,16 @@ func (w *walker) MapElem(m, k, v reflect.Value) error {
 }
 
 func (w *walker) PointerEnter(v bool) error {
-	if w.ignoring() {
-		return nil
+	if v {
+		w.ps[w.depth]++
 	}
-
-	w.ps = append(w.ps, v)
 	return nil
 }
 
-func (w *walker) PointerExit(bool) error {
-	if w.ignoring() {
-		return nil
+func (w *walker) PointerExit(v bool) error {
+	if v {
+		w.ps[w.depth]--
 	}
-
-	w.ps = w.ps[:len(w.ps)-1]
 	return nil
 }
 
@@ -219,7 +221,7 @@ func (w *walker) Primitive(v reflect.Value) error {
 	var newV reflect.Value
 	if v.IsValid() && v.CanInterface() {
 		newV = reflect.New(v.Type())
-		reflect.Indirect(newV).Set(v)
+		newV.Elem().Set(v)
 	}
 
 	w.valPush(newV)
@@ -318,7 +320,7 @@ func (w *walker) ignoring() bool {
 }
 
 func (w *walker) pointerPeek() bool {
-	return w.ps[len(w.ps)-1]
+	return w.ps[w.depth] > 0
 }
 
 func (w *walker) valPop() reflect.Value {
@@ -350,7 +352,17 @@ func (w *walker) replacePointerMaybe() {
 	// we need to push that onto the stack.
 	if !w.pointerPeek() {
 		w.valPush(reflect.Indirect(w.valPop()))
+		return
 	}
+
+	v := w.valPop()
+	for i := 1; i < w.ps[w.depth]; i++ {
+		p := reflect.New(v.Type())
+		p.Elem().Set(v)
+		v = p
+	}
+
+	w.valPush(v)
 }
 
 // if this value is a Locker, lock it and add it to the locks slice

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -42,20 +42,23 @@ func TestCopy_primitive(t *testing.T) {
 }
 
 func TestCopy_primitivePtr(t *testing.T) {
+	i := 42
+	s := "foo"
+	f := 1.2
 	cases := []interface{}{
-		42,
-		"foo",
-		1.2,
+		&i,
+		&s,
+		&f,
 	}
 
-	for _, tc := range cases {
+	for i, tc := range cases {
 		result, err := Copy(&tc)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
-		if !reflect.DeepEqual(result, &tc) {
-			t.Fatalf("bad: %#v", result)
+		if !reflect.DeepEqual(result, tc) {
+			t.Fatalf("%d exptected: %#v\nbad: %#v", i, tc, result)
 		}
 	}
 }

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -1,6 +1,7 @@
 package copystructure
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -52,7 +53,7 @@ func TestCopy_primitivePtr(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		result, err := Copy(&tc)
+		result, err := Copy(tc)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -676,3 +677,102 @@ func TestCopy_structWithMapWithPointers(t *testing.T) {
 		t.Fatal(result)
 	}
 }
+
+type testT struct {
+	N   int
+	Spp **string
+	X   testX
+	Xp  *testX
+	Xpp **testX
+}
+
+type testX struct {
+	Tp  *testT
+	Tpp **testT
+	Ip  *interface{}
+	Ep  *error
+	S   fmt.Stringer
+}
+
+type stringer struct{}
+
+func (s *stringer) String() string {
+	return "test string"
+}
+
+func TestCopy_structWithPointersAndInterfaces(t *testing.T) {
+	// test that we can copy various nested and chained pointers and interfaces
+	s := "val"
+	sp := &s
+	spp := &sp
+	i := interface{}(11)
+
+	tp := &testT{
+		N: 2,
+	}
+
+	xp := &testX{
+		Tp:  tp,
+		Tpp: &tp,
+		Ip:  &i,
+		S:   &stringer{},
+	}
+
+	v := &testT{
+		N:   1,
+		Spp: spp,
+		X:   testX{},
+		Xp:  xp,
+		Xpp: &xp,
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatal(result)
+	}
+}
+
+/* TODO: failing tests
+
+// This fails by returning an interface{}(**string) rather than an
+// *interface{}(*string)
+func Test_pointerInterfacePointer(t *testing.T) {
+	s := "hi"
+	si := interface{}(&s)
+	sip := &si
+
+	result, err := Copy(sip)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(sip, result) {
+		t.Fatalf("%#v != %#v\n", sip, result)
+	}
+}
+
+// This panics because it tries to assign a **int to an *interface{}, again
+// getting the number of pointer around the interface wrong.
+func Test_pointerInterfacePointer2(t *testing.T) {
+	type T struct {
+		I *interface{}
+	}
+	i := interface{}(new(int))
+
+	v := &T{
+		I: &i,
+	}
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("%#v != %#v\n", v, result)
+	}
+}
+*/


### PR DESCRIPTION
The test was actually testing pointers to an interface{}, not pointers
to a primitive. This shows up when reflectwalk starts handling nested references.