### PR TITLE
Use new reflectwalk.SkipEntry as a cleaner way to skip unexported fields

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -312,8 +312,7 @@ func (w *walker) StructField(f reflect.StructField, v reflect.Value) error {
 	// If PkgPath is non-empty, this is a private (unexported) field.
 	// We do not set this unexported since the Go runtime doesn't allow us.
 	if f.PkgPath != "" {
-		w.ignore()
-		return nil
+		return reflectwalk.SkipEntry
 	}
 
 	// Push the field onto the stack, we'll handle it when we exit

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -776,3 +776,31 @@ func Test_pointerInterfacePointer2(t *testing.T) {
 	}
 }
 */
+
+// This test catches a bug that happened when unexported fields were
+// first their subsequent fields wouldn't be copied.
+func TestCopy_unexportedFieldFirst(t *testing.T) {
+	type P struct {
+		mu       sync.Mutex
+		Old, New string
+	}
+
+	type T struct {
+		M map[string]*P
+	}
+
+	v := &T{
+		M: map[string]*P{
+			"a": &P{Old: "", New: "2"},
+		},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("\n%#v\n\n%#v", v, result)
+	}
+}


### PR DESCRIPTION
Prior to this, `ignore()` was used which ignores the entire _depth_
value which is actually all the struct fields that follow. What we
actually want to do is just ignore this single entry, which is what this
new reflectwalk API does.