### PR TITLE
Implement InterfaceWalker

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -82,6 +82,14 @@ func (c Config) Copy(v interface{}) (interface{}, error) {
 	return result, nil
 }
 
+// Return the key used to index interfaces types we've seen. Store the number
+// of pointers in the upper 32bits, and the depth in the lower 32bits. This is
+// easy to calculate, easy to match a key with our current depth, and we don't
+// need to deal with initializing and cleaning up nested maps or slices.
+func ifaceKey(pointers, depth int) uint64 {
+	return uint64(pointers)<<32 | uint64(depth)
+}
+
 type walker struct {
 	Result interface{}
 
@@ -89,7 +97,16 @@ type walker struct {
 	ignoreDepth int
 	vals        []reflect.Value
 	cs          []reflect.Value
-	ps          []int
+
+	// This stores the number of pointers we've walked over, indexed by depth.
+	ps []int
+
+	// If an interface is indirected by a pointer, we need to know the type of
+	// interface to create when creating the new value.  Store the interface
+	// types here, indexed by both the walk depth and the number of pointers
+	// already seen at that depth. Use ifaceKey to calculate the proper uint64
+	// value.
+	ifaceTypes map[uint64]reflect.Type
 
 	// any locks we've taken, indexed by depth
 	locks []sync.Locker
@@ -119,7 +136,16 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 		defer locker.Unlock()
 	}
 
+	// clear out pointers and interfaces as we exit the stack
 	w.ps[w.depth] = 0
+
+	for k := range w.ifaceTypes {
+		mask := uint64(^uint32(0))
+		if k&mask == uint64(w.depth) {
+			delete(w.ifaceTypes, k)
+		}
+	}
+
 	w.depth--
 	if w.ignoreDepth > w.depth {
 		w.ignoreDepth = 0
@@ -219,6 +245,18 @@ func (w *walker) PointerExit(v bool) error {
 	if v {
 		w.ps[w.depth]--
 	}
+	return nil
+}
+
+func (w *walker) Interface(v reflect.Value) error {
+	if !v.IsValid() {
+		return nil
+	}
+	if w.ifaceTypes == nil {
+		w.ifaceTypes = make(map[uint64]reflect.Type)
+	}
+
+	w.ifaceTypes[ifaceKey(w.ps[w.depth], w.depth)] = v.Type()
 	return nil
 }
 
@@ -368,6 +406,12 @@ func (w *walker) replacePointerMaybe() {
 
 	v := w.valPop()
 	for i := 1; i < w.ps[w.depth]; i++ {
+		if iType, ok := w.ifaceTypes[ifaceKey(w.ps[w.depth]-i, w.depth)]; ok {
+			iface := reflect.New(iType).Elem()
+			iface.Set(v)
+			v = iface
+		}
+
 		p := reflect.New(v.Type())
 		p.Elem().Set(v)
 		v = p

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -736,10 +736,6 @@ func TestCopy_structWithPointersAndInterfaces(t *testing.T) {
 	}
 }
 
-/* TODO: failing tests
-
-// This fails by returning an interface{}(**string) rather than an
-// *interface{}(*string)
 func Test_pointerInterfacePointer(t *testing.T) {
 	s := "hi"
 	si := interface{}(&s)
@@ -755,16 +751,22 @@ func Test_pointerInterfacePointer(t *testing.T) {
 	}
 }
 
-// This panics because it tries to assign a **int to an *interface{}, again
-// getting the number of pointer around the interface wrong.
 func Test_pointerInterfacePointer2(t *testing.T) {
 	type T struct {
 		I *interface{}
+		J **fmt.Stringer
 	}
-	i := interface{}(new(int))
+
+	x := 1
+	y := &stringer{}
+
+	i := interface{}(&x)
+	j := fmt.Stringer(y)
+	jp := &j
 
 	v := &T{
 		I: &i,
+		J: &jp,
 	}
 	result, err := Copy(v)
 	if err != nil {
@@ -775,7 +777,6 @@ func Test_pointerInterfacePointer2(t *testing.T) {
 		t.Fatalf("%#v != %#v\n", v, result)
 	}
 }
-*/
 
 // This test catches a bug that happened when unexported fields were
 // first their subsequent fields wouldn't be copied.


### PR DESCRIPTION
InterfaceWalker allows us to record specific interface types when
walking over chains of pointer and interfaces. The walker will record
each interface type encountered, indexed by the walk depth and number of
pointers.

Fixes both previously failing tests, and also made the second test a little more insane.

Requires reflectwalk#15