### PR TITLE
Always pop the slice index off the stack

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -177,8 +177,8 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 	case reflectwalk.SliceElem:
 		// Pop off the value and the index and set it on the slice
 		v := w.valPop()
+		i := w.valPop().Interface().(int)
 		if v.IsValid() {
-			i := w.valPop().Interface().(int)
 			s := w.cs[len(w.cs)-1]
 			se := s.Index(i)
 			if se.CanSet() {

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -805,3 +805,22 @@ func TestCopy_unexportedFieldFirst(t *testing.T) {
 		t.Fatalf("\n%#v\n\n%#v", v, result)
 	}
 }
+
+func TestCopy_nilPointerInSlice(t *testing.T) {
+	type T struct {
+		Ps []*int
+	}
+
+	v := &T{
+		Ps: []*int{nil},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("\n%#v\n\n%#v", v, result)
+	}
+}


### PR DESCRIPTION
When encountering an invalid value for a slice, we still need to pop the
index off the stack or it will throw off the rest of the walk.