### PR TITLE
copy interface pointers (arbitrarily deep)

### DIFF
--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -24,6 +24,32 @@ func TestCopy_complex(t *testing.T) {
 	}
 }
 
+func TestCopy_interfacePointer(t *testing.T) {
+	type Nested struct {
+		Field string
+	}
+
+	type Test struct {
+		Value *interface{}
+	}
+
+	ifacePtr := func(v interface{}) *interface{} {
+		return &v
+	}
+
+	v := Test{
+		Value: ifacePtr(Nested{Field: "111"}),
+	}
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestCopy_primitive(t *testing.T) {
 	cases := []interface{}{
 		42,


### PR DESCRIPTION
Fixes #16

This properly converts a reflected value to `*interface{}` (with any
number of `*` nesting) so that it is settable.

When a field is `interface{}` (no pointer), any value is settable to it.
But when a field is `*interface{}` (one or more pointers), then pointer
values are not assignable to it, it must _exactly_ match `*interface{}`.

The code added in this PR checks for this scenario and converts.