### PR TITLE
support pointer to collections case

### DIFF
--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -118,6 +118,32 @@ func TestCopy_slice(t *testing.T) {
 	}
 }
 
+func TestCopy_pointerToSlice(t *testing.T) {
+	v := &[]string{"bar", "baz"}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_pointerToMap(t *testing.T) {
+	v := &map[string]string{"bar": "baz"}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestCopy_struct(t *testing.T) {
 	type test struct {
 		Value string
@@ -177,6 +203,44 @@ func TestCopy_structNested(t *testing.T) {
 	}
 
 	v := Test{}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_structWithPointerToSliceField(t *testing.T) {
+	type Test struct {
+		Value *[]string
+	}
+
+	v := Test{
+		Value: &[]string{"bar", "baz"},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_structWithPointerToMapField(t *testing.T) {
+	type Test struct {
+		Value *map[string]string
+	}
+
+	v := Test{
+		Value: &map[string]string{"bar": "baz"},
+	}
 
 	result, err := Copy(v)
 	if err != nil {
@@ -513,14 +577,14 @@ func TestCopy_lockedMap(t *testing.T) {
 	<-copied
 
 	// test that the mutex is in the correct state
-	result.(lockedMap).Lock()
-	result.(lockedMap).Unlock()
+	result.(*lockedMap).Lock()
+	result.(*lockedMap).Unlock()
 
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !reflect.DeepEqual(result, v) {
+	if !reflect.DeepEqual(result, &v) {
 		t.Fatalf("bad: %#v", result)
 	}
 }


### PR DESCRIPTION
Fix for #20 

Not sure if this fix can be considered a proper solution - it only removes _consequences_, but does not fix _root cause_.

One more thing to note is backward compatibility concerns - previously for input like `*map[string]string` result would be `map[string]string` (not a pointer), and there is even test relying on such behavior (not very explicitly though, test itself is about locking). This behavior does not look right for me (why would type of copied result be different comparing to input?) - but there might be some code _relying_ on such behavior somewhere.