### PR TITLE
support pointer to collections case

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -159,6 +159,7 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 	case reflectwalk.Map:
 		fallthrough
 	case reflectwalk.Slice:
+		w.replacePointerMaybe()
 		// Pop map off our container
 		w.cs = w.cs[:len(w.cs)-1]
 	case reflectwalk.MapValue:
@@ -171,16 +172,16 @@ func (w *walker) Exit(l reflectwalk.Location) error {
 		// or in this case never adds it. We need to create a properly typed
 		// zero value so that this key can be set.
 		if !mv.IsValid() {
-			mv = reflect.Zero(m.Type().Elem())
+			mv = reflect.Zero(m.Elem().Type().Elem())
 		}
-		m.SetMapIndex(mk, mv)
+		m.Elem().SetMapIndex(mk, mv)
 	case reflectwalk.SliceElem:
 		// Pop off the value and the index and set it on the slice
 		v := w.valPop()
 		i := w.valPop().Interface().(int)
 		if v.IsValid() {
 			s := w.cs[len(w.cs)-1]
-			se := s.Index(i)
+			se := s.Elem().Index(i)
 			if se.CanSet() {
 				se.Set(v)
 			}
@@ -220,9 +221,9 @@ func (w *walker) Map(m reflect.Value) error {
 	// Create the map. If the map itself is nil, then just make a nil map
 	var newMap reflect.Value
 	if m.IsNil() {
-		newMap = reflect.Indirect(reflect.New(m.Type()))
+		newMap = reflect.New(m.Type())
 	} else {
-		newMap = reflect.MakeMap(m.Type())
+		newMap = wrapPtr(reflect.MakeMap(m.Type()))
 	}
 
 	w.cs = append(w.cs, newMap)
@@ -287,9 +288,9 @@ func (w *walker) Slice(s reflect.Value) error {
 
 	var newS reflect.Value
 	if s.IsNil() {
-		newS = reflect.Indirect(reflect.New(s.Type()))
+		newS = reflect.New(s.Type())
 	} else {
-		newS = reflect.MakeSlice(s.Type(), s.Len(), s.Cap())
+		newS = wrapPtr(reflect.MakeSlice(s.Type(), s.Len(), s.Cap()))
 	}
 
 	w.cs = append(w.cs, newS)
@@ -491,4 +492,13 @@ func (w *walker) lock(v reflect.Value) {
 
 	locker.Lock()
 	w.locks[w.depth] = locker
+}
+
+func wrapPtr(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
+	vPtr := reflect.New(v.Type())
+	vPtr.Elem().Set(v)
+	return vPtr
 }

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -118,6 +118,32 @@ func TestCopy_slice(t *testing.T) {
 	}
 }
 
+func TestCopy_pointerToSlice(t *testing.T) {
+	v := &[]string{"bar", "baz"}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_pointerToMap(t *testing.T) {
+	v := &map[string]string{"bar": "baz"}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestCopy_struct(t *testing.T) {
 	type test struct {
 		Value string
@@ -177,6 +203,44 @@ func TestCopy_structNested(t *testing.T) {
 	}
 
 	v := Test{}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_structWithPointerToSliceField(t *testing.T) {
+	type Test struct {
+		Value *[]string
+	}
+
+	v := Test{
+		Value: &[]string{"bar", "baz"},
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(result, v) {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCopy_structWithPointerToMapField(t *testing.T) {
+	type Test struct {
+		Value *map[string]string
+	}
+
+	v := Test{
+		Value: &map[string]string{"bar": "baz"},
+	}
 
 	result, err := Copy(v)
 	if err != nil {
@@ -513,14 +577,14 @@ func TestCopy_lockedMap(t *testing.T) {
 	<-copied
 
 	// test that the mutex is in the correct state
-	result.(lockedMap).Lock()
-	result.(lockedMap).Unlock()
+	result.(*lockedMap).Lock()
+	result.(*lockedMap).Unlock()
 
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !reflect.DeepEqual(result, v) {
+	if !reflect.DeepEqual(result, &v) {
 		t.Fatalf("bad: %#v", result)
 	}
 }


### PR DESCRIPTION
Another fix for #20 (mutually exclusive regarding previous pull request - the #21 one).

This change seems to fix _root cause_ of the behaviour described at #20 - most of the values (primitives/structs/arrays in another PR around) saved to stack as pointers, and logic within `replacePointerMaybe` relies on this - but slices and maps are not obeying this rule (not sure if that's intentional), and that's why we receive unexpected type as described in #20.

Same backward compatibility concerns as in #21 apply here - previously for input like `*map[string]string` result would be `map[string]string` (not a pointer), and there is even test relying on such behaviour (not very explicitly though, test itself is about locking). This behaviour does not look right for me (why would type of copied result be different comparing to input?) - but there might be some code relying on such behaviour somewhere.