### PR TITLE
copiers need to push a pointer value onto the value stack

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -366,7 +366,10 @@ func (w *walker) Struct(s reflect.Value) error {
 			return err
 		}
 
-		v = reflect.ValueOf(dup)
+		// We need to put a pointer to the value on the value stack,
+		// so allocate a new pointer and set it.
+		v = reflect.New(s.Type())
+		reflect.Indirect(v).Set(reflect.ValueOf(dup))
 	} else {
 		// No copier, we copy ourselves and allow reflectwalk to guide
 		// us deeper into the structure for copying.

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -1015,3 +1015,69 @@ func TestCopy_nilPointerInSlice(t *testing.T) {
 		t.Fatalf("\n%#v\n\n%#v", v, result)
 	}
 }
+
+//-------------------------------------------------------------------
+// The tests below all tests various pointer cases around copying
+// a structure that uses a defined Copier. This was originally raised
+// around issue #26.
+
+func TestCopy_timePointer(t *testing.T) {
+	type T struct {
+		Value *time.Time
+	}
+
+	now := time.Now()
+	v := &T{
+		Value: &now,
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("\n%#v\n\n%#v", v, result)
+	}
+}
+
+func TestCopy_timeNonPointer(t *testing.T) {
+	type T struct {
+		Value time.Time
+	}
+
+	v := &T{
+		Value: time.Now(),
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("\n%#v\n\n%#v", v, result)
+	}
+}
+
+func TestCopy_timeDoublePointer(t *testing.T) {
+	type T struct {
+		Value **time.Time
+	}
+
+	now := time.Now()
+	nowP := &now
+	nowPP := &nowP
+	v := &T{
+		Value: nowPP,
+	}
+
+	result, err := Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(v, result) {
+		t.Fatalf("\n%#v\n\n%#v", v, result)
+	}
+}


### PR DESCRIPTION
Fixes #26 

Any value that is copied with a Copier must push a pointer value back onto the value stack in order to be set properly on any number of pointer struct elements. 

I included extra tests around copiers that aren't pointers and verified that still works.