### PR TITLE
Use custom copiers declared in Config

### DIFF
--- a/copystructure.go
+++ b/copystructure.go
@@ -88,6 +88,7 @@ func (c Config) Copy(v interface{}) (interface{}, error) {
 	if c.Copiers == nil {
 		c.Copiers = Copiers
 	}
+	w.copiers = c.Copiers
 
 	err := reflectwalk.Walk(v, w)
 	if err != nil {
@@ -116,6 +117,7 @@ func ifaceKey(pointers, depth int) uint64 {
 type walker struct {
 	Result interface{}
 
+	copiers     map[reflect.Type]CopierFunc
 	depth       int
 	ignoreDepth int
 	vals        []reflect.Value
@@ -379,7 +381,7 @@ func (w *walker) Struct(s reflect.Value) error {
 	w.lock(s)
 
 	var v reflect.Value
-	if c, ok := Copiers[s.Type()]; ok {
+	if c, ok := w.copiers[s.Type()]; ok {
 		// We have a Copier for this struct, so we use that copier to
 		// get the copy, and we ignore anything deeper than this.
 		w.ignoreDepth = w.depth

--- a/copystructure_test.go
+++ b/copystructure_test.go
@@ -1153,3 +1153,37 @@ func TestCopy_timeDoublePointer(t *testing.T) {
 		t.Fatalf("\n%#v\n\n%#v", v, result)
 	}
 }
+
+type nestedValue struct {
+	v string
+}
+
+func TestCopy_customCopierConfig(t *testing.T) {
+	type T struct {
+		Val *nestedValue
+	}
+
+	v := &T{
+		Val: &nestedValue{v: "original"},
+	}
+
+	cfg := Config{
+		Copiers: map[reflect.Type]CopierFunc{
+			reflect.TypeOf(nestedValue{}): customCopier,
+		},
+	}
+	result, err := cfg.Copy(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copiedVal := result.(*T)
+
+	if !reflect.DeepEqual(v.Val.v, copiedVal.Val.v) {
+		t.Fatalf("\nexpected: %#v\ngiven: %#v", v.Val.v, copiedVal.Val.v)
+	}
+}
+
+func customCopier(v interface{}) (interface{}, error) {
+	return v.(nestedValue), nil
+}


### PR DESCRIPTION
Fixes #31

I ran into a weird issue in Terraform LS where certain struct fields weren't being copied under some circumstances and I found this was because an external imported package also uses copystructure and overrides custom copiers.

Ideally I'd like to just avoid the global state entirely, but this doesn't seem possible until this bug is fixed.